### PR TITLE
feature: Add option to open setup wizard after the initial setup

### DIFF
--- a/blackboard_sync/qt/SettingsWindow.ui
+++ b/blackboard_sync/qt/SettingsWindow.ui
@@ -125,7 +125,7 @@ QLabel:enabled {color:white}
        <property name="sizeHint" stdset="0">
         <size>
          <width>0</width>
-         <height>18</height>
+         <height>12</height>
         </size>
        </property>
       </spacer>
@@ -182,7 +182,7 @@ QLabel:enabled {color:white}
        <property name="sizeHint" stdset="0">
         <size>
          <width>0</width>
-         <height>18</height>
+         <height>12</height>
         </size>
        </property>
       </spacer>
@@ -217,17 +217,34 @@ QLabel:enabled {color:white}
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="log_out_button">
-       <property name="font">
-        <font>
-         <family>Open Sans</family>
-         <pointsize>11</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Log Out</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QPushButton" name="log_out_button">
+         <property name="font">
+          <font>
+           <family>Open Sans</family>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Log Out</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="setup_button">
+         <property name="font">
+          <font>
+           <family>Open Sans</family>
+           <pointsize>11</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Setup Wizard</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
       <spacer name="verticalSpacer_4">
@@ -240,7 +257,7 @@ QLabel:enabled {color:white}
        <property name="sizeHint" stdset="0">
         <size>
          <width>0</width>
-         <height>27</height>
+         <height>24</height>
         </size>
        </property>
       </spacer>

--- a/blackboard_sync/qt/qt_elements.py
+++ b/blackboard_sync/qt/qt_elements.py
@@ -164,6 +164,9 @@ class SyncTrayMenu(QMenu):
         self.log_in = QAction("Log In")
         self.addAction(self.log_in)
 
+        self.reset_setup = QAction("Redo Setup")
+        self.addAction(self.reset_setup)
+
         self.quit = QAction("Quit")
         self.quit.setIcon(close_icon)
         self.addAction(self.quit)
@@ -172,6 +175,7 @@ class SyncTrayMenu(QMenu):
         """Set the UI to reflect logged-in status."""
         self.refresh.setVisible(logged)
         self.preferences.setVisible(logged)
+        self.reset_setup.setVisible(not logged)
         self.open_dir.setVisible(logged)
         self.log_in.setVisible(not logged)
 
@@ -200,6 +204,7 @@ class SyncTrayIcon(QSystemTrayIcon):
     _sync_signal = pyqtSignal()
     _login_signal = pyqtSignal()
     _settings_signal = pyqtSignal()
+    _reset_setup_signal = pyqtSignal()
     _quit_signal = pyqtSignal()
     _open_dir_signal = pyqtSignal()
     _show_menu_signal = pyqtSignal()
@@ -223,6 +228,7 @@ class SyncTrayIcon(QSystemTrayIcon):
         self._sync_signal = self._menu.refresh.triggered
         self._login_signal = self._menu.log_in.triggered
         self._settings_signal = self._menu.preferences.triggered
+        self._reset_setup_signal = self._menu.reset_setup.triggered
         self._quit_signal = self._menu.quit.triggered
         self._open_dir_signal = self._menu.open_dir.triggered
         self._show_menu_signal = self._menu.aboutToShow
@@ -267,6 +273,11 @@ class SyncTrayIcon(QSystemTrayIcon):
     def settings_signal(self):
         """Fire when the settings menu is opened."""
         return self._settings_signal
+
+    @property
+    def reset_setup_signal(self):
+        """Fire when the user wants to reset the initial setup."""
+        return self._reset_setup_signal
 
     @property
     def quit_signal(self):
@@ -363,6 +374,7 @@ class SettingsWindow(QWidget):
     _window_title = "Settings"
     _initial_position = (300, 300)
     _log_out_signal = pyqtSignal()
+    _setup_wiz_signal = pyqtSignal()
     _save_signal = pyqtSignal()
 
     def __init__(self):
@@ -378,6 +390,7 @@ class SettingsWindow(QWidget):
 
         self.select_download_location.clicked.connect(self._choose_location)
         self._log_out_signal = self.log_out_button.clicked
+        self._setup_wiz_signal = self.setup_button.clicked
         self._save_signal = self.button_box.accepted
 
     def _choose_location(self) -> None:
@@ -431,6 +444,11 @@ class SettingsWindow(QWidget):
         return self._log_out_signal
 
     @property
+    def setup_wiz_signal(self):
+        """Fire when user wants to redo initial setup."""
+        return self._setup_wiz_signal
+
+    @property
     def save_signal(self):
         """Fire when settings are saved."""
         return self._save_signal
@@ -474,6 +492,7 @@ class LoginWebView(QWidget):
         )
 
     def restore(self) -> None:
+        self.web_view.setPage(None)
         self.clear_cookie_store()
         self.web_view.load(QUrl.fromUserInput(self.start_url))
 

--- a/blackboard_sync/sync_controller.py
+++ b/blackboard_sync/sync_controller.py
@@ -67,12 +67,14 @@ class BBSyncController:
         self.config_window = SettingsWindow()
 
         self.config_window.log_out_signal.connect(self._log_out)
+        self.config_window.setup_wiz_signal.connect(self._reset_setup)
         self.config_window.save_signal.connect(self._save_setting_changes)
 
         self.tray = SyncTrayIcon()
         self.tray.quit_signal.connect(self._stop)
         self.tray.login_signal.connect(self._show_login_window)
         self.tray.settings_signal.connect(self._show_config_window)
+        self.tray.reset_setup_signal.connect(self._reset_setup)
         self.tray.sync_signal.connect(self._force_sync)
         self.tray.activated.connect(self._tray_icon_activated)
         self.tray.open_dir_signal.connect(self._open_download_dir)
@@ -103,6 +105,13 @@ class BBSyncController:
         self.app.restoreOverrideCursor()
         self._check_for_updates()
         self.tray.show_msg('The download has started', 'BlackboardSync is running in the background. Find it in the system tray.')
+
+    def _reset_setup(self) -> None:
+        # Hide login window and show setup wizard
+        if self.login_window is not None:
+            self._log_out()
+            self.login_window.setVisible(False)
+        self._show_setup_window()
 
     def _check_for_updates(self) -> None:
         if (html_url := check_for_updates()) is not None:
@@ -141,6 +150,9 @@ class BBSyncController:
                 self._show_login_window()
 
     def _log_out(self) -> None:
+        if self.model.is_active:
+            self.model.stop_sync()
+
         self.model.log_out()
         self.tray.set_logged_in(False)
         self.login_window.restore()

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -230,6 +230,14 @@ class TestSettingsWindow:
             qtbot.mouseClick(settings_window.log_out_button, QtCore.Qt.LeftButton)
 
         assert blocker.signal_triggered
+    
+    def test_settings_window_setup_wizard_signal(self, qtbot, settings_window):
+        qtbot.addWidget(settings_window)
+
+        with qtbot.waitSignal(settings_window.setup_wiz_signal) as blocker:
+            qtbot.mouseClick(settings_window.setup_button, QtCore.Qt.LeftButton)
+
+        assert blocker.signal_triggered
 
     def test_settings_window_save_signal(self, qtbot, settings_window):
         qtbot.addWidget(settings_window)
@@ -272,6 +280,12 @@ class TestSyncTrayIcon:
     def test_tray_icon_login_signal(self, qtbot, tray_icon):
         with qtbot.waitSignal(tray_icon.login_signal) as blocker:
             tray_icon._menu.log_in.trigger()
+
+        assert blocker.signal_triggered
+
+    def test_tray_icon_setupwiz_signal(self, qtbot, tray_icon):
+        with qtbot.waitSignal(tray_icon.reset_setup_signal) as blocker:
+            tray_icon._menu.reset_setup.trigger()
 
         assert blocker.signal_triggered
 


### PR DESCRIPTION
These changes add an option for the user to redo the setup wizard after the initial setup, both before and after logging in.
This change is necessary to avoid situations where the user mistakenly chooses the wrong institution during setup, since there used to be no way of reverting this change besides deleting the configuration file.

Before logging in, this is shown as an item in the system tray icon, since the settings menu is not yet accessible at this point. After login, the option exists within the settings menu.

Additionally, a minor bug should have been fixed, where the app would not log out of the session due to still being on the target URL.