### PR TITLE
Created new BBAvailable enum

### DIFF
--- a/blackboard_sync/blackboard/__init__.py
+++ b/blackboard_sync/blackboard/__init__.py
@@ -7,7 +7,7 @@ A python interface for the Blackboard REST APIs.
 
 Basic usage:
     >>> from blackboard import BlackboardSession
-    >>> s = BlackboardSession(user='example', password='password')
+    >>> s = BlackboardSession(base_url='https://...', cookies=...)
     >>> s.fetch_version()
 
 
@@ -37,9 +37,10 @@ from .api import BlackboardSession
 from .blackboard import (BBFile, BBLink, BBCourse, BBLocale, BBDuration,
                          BBAttachment, BBEnrollment, BBMembership,
                          BBProctoring, BBAvailability, BBContentChild,
-                         BBCourseContent, BBContentHandler, BBResourceType)
+                         BBCourseContent, BBContentHandler, BBResourceType,
+                         BBAvailable)
 
 __all__ = ['BBLocale', 'BBDuration', 'BBEnrollment', 'BBProctoring', 'BBFile',
            'BBAttachment', 'BBLink', 'BBContentHandler', 'BBAvailability',
            'BBCourseContent', 'BBContentChild', 'BBMembership', 'BBCourse',
-           'BlackboardSession', 'BBResourceType']
+           'BlackboardSession', 'BBResourceType', 'BBAvailable']

--- a/blackboard_sync/blackboard/blackboard.py
+++ b/blackboard_sync/blackboard/blackboard.py
@@ -22,7 +22,7 @@ from enum import Enum
 from datetime import datetime
 from typing import Union, Optional
 
-from pydantic import BaseModel, field_validator, ConfigDict
+from pydantic import BaseModel, Field, field_validator, ConfigDict
 from pathvalidate import sanitize_filename
 
 
@@ -93,17 +93,18 @@ class BBAvailable(str, Enum):
 
 
 class BBAvailability(ImmutableModel):
-    available: Union[BBAvailable, str, None]
+    available: Union[BBAvailable, bool, str, None]
     allowGuests: bool = False
     adaptiveRelease: dict = {}
     duration: Optional[BBDuration] = None
     
     @field_validator('available')
-    def available_parser(cls, v: Union[BBAvailable, str]):
+    def available_parser(cls, v: Union[BBAvailable, bool, str]):
         if isinstance(v, BBAvailable) or v in BBAvailable.__members__:
+            # v is BBAvailable or a string matching a variant
             return BBAvailable(v)
         else:
-            # Unrecognized string contents
+            # Unrecognized string contents or a bool
             # TODO: Log, suggest issue when encountered
             return v
 

--- a/blackboard_sync/blackboard/blackboard.py
+++ b/blackboard_sync/blackboard/blackboard.py
@@ -81,11 +81,30 @@ class BBLink(ImmutableModel):
     type: Optional[str] = None
 
 
+class BBAvailable(str, Enum):
+    Yes = 'Yes'
+    Term = 'Term'
+    No = 'No'
+    Disabled = 'Disabled'
+    
+    def __bool__(self) -> bool:
+        return not self in (BBAvailable.No, BBAvailable.Disabled)
+
+
 class BBAvailability(ImmutableModel):
-    available: Union[bool, str, None] = None
+    available: Union[BBAvailable, str, None]
     allowGuests: bool = False
     adaptiveRelease: dict = {}
     duration: Optional[BBDuration] = None
+    
+    @field_validator('available')
+    def available_parser(cls, v: Union[BBAvailable, str]):
+        if isinstance(v, BBAvailable) or v in BBAvailable.__members__:
+            return BBAvailable(v)
+        else:
+            # Unrecognized string contents
+            # TODO: Log, suggest issue when encountered
+            return v
 
 
 class BBMembership(ImmutableModel):

--- a/blackboard_sync/blackboard/blackboard.py
+++ b/blackboard_sync/blackboard/blackboard.py
@@ -22,7 +22,7 @@ from enum import Enum
 from datetime import datetime
 from typing import Union, Optional
 
-from pydantic import BaseModel, Field, field_validator, ConfigDict
+from pydantic import BaseModel, field_validator, ConfigDict
 from pathvalidate import sanitize_filename
 
 
@@ -82,31 +82,26 @@ class BBLink(ImmutableModel):
 
 
 class BBAvailable(str, Enum):
-    yes = 'Yes'
-    term = 'Term'
-    no = 'No'
-    disabled = 'Disabled'
-    partially_visible = 'PartiallyVisible'
-    
+    Yes = 'Yes'
+    Term = 'Term'
+    No = 'No'
+    Disabled = 'Disabled'
+    PartiallyVisible = 'PartiallyVisible'
+    Other = '__blackboardsync_other'
+
+    @classmethod
+    def _missing_(cls, value: str) -> 'BBAvailable':
+        return cls.Other
+
     def __bool__(self) -> bool:
         return not self in (BBAvailable.No, BBAvailable.Disabled)
 
 
 class BBAvailability(ImmutableModel):
-    available: Union[BBAvailable, bool, str, None]
+    available: Optional[BBAvailable] = None
     allowGuests: bool = False
     adaptiveRelease: dict = {}
     duration: Optional[BBDuration] = None
-    
-    @field_validator('available')
-    def available_parser(cls, v: Union[BBAvailable, bool, str]):
-        if isinstance(v, BBAvailable) or v in BBAvailable.__members__:
-            # v is BBAvailable or a string matching a variant
-            return BBAvailable(v)
-        else:
-            # Unrecognized string contents or a bool
-            # TODO: Log, suggest issue when encountered
-            return v
 
 
 class BBMembership(ImmutableModel):

--- a/blackboard_sync/blackboard/blackboard.py
+++ b/blackboard_sync/blackboard/blackboard.py
@@ -82,10 +82,11 @@ class BBLink(ImmutableModel):
 
 
 class BBAvailable(str, Enum):
-    Yes = 'Yes'
-    Term = 'Term'
-    No = 'No'
-    Disabled = 'Disabled'
+    yes = 'Yes'
+    term = 'Term'
+    no = 'No'
+    disabled = 'Disabled'
+    partially_visible = 'PartiallyVisible'
     
     def __bool__(self) -> bool:
         return not self in (BBAvailable.No, BBAvailable.Disabled)


### PR DESCRIPTION
Previously, the `available` field of a BBAvailability was allowed to simply be a string, which prevented users from verifying the effective boolean value of the `available` field. Now, the `available` field is mapped to a BBAvailable enum, which has a boolean cast method. If that enum does not contain the string that BBAvailability is passed on construction, then BBAvailability will allow itself to contain a string in the `available` field. Casting a string to a bool returns True unless the string is empty, so the field will behave generally as expected.