### PR TITLE
Support University of Antwerp

### DIFF
--- a/blackboard_sync/download.py
+++ b/blackboard_sync/download.py
@@ -203,7 +203,7 @@ class BlackboardDownload:
                 download_path = Path(file_path / safe_title)
                 self.executor.submit(self._download_webdav_file, body_link.href, download_path)
 
-            with Path(file_path, f"{content.title_path_safe}.html").open('w') as html_content:
+            with Path(file_path, f"{content.title_path_safe}.html").open('w', encoding='utf-8') as html_content:
                 html_content.write(parser.body)
 
     def download(self) -> Optional[datetime]:

--- a/blackboard_sync/universities.json
+++ b/blackboard_sync/universities.json
@@ -353,10 +353,10 @@
     "name": "University of Antwerp",
     "short_name": "Universiteit Antwerpen",
     "login": {
-      "start_url": "https://blackboard.uantwerpen.be",
-      "target_url": "https://blackboard.uantwerpen.be/webapps/portal/"
+      "start_url": "https://lms.uantwerpen.be",
+      "target_url": "https://lms.uantwerpen.be/ultra"
     },
-    "api_url": "https://blackboard.uantwerpen.be/"
+    "api_url": "https://lms.uantwerpen.be/"
   },
   {
     "name": "The Chinese University of Hong Kong",

--- a/blackboard_sync/universities.json
+++ b/blackboard_sync/universities.json
@@ -354,7 +354,7 @@
     "short_name": "Universiteit Antwerpen",
     "login": {
       "start_url": "https://lms.uantwerpen.be",
-      "target_url": "https://lms.uantwerpen.be/ultra"
+      "target_url": "https://lms.uantwerpen.be/ultra/"
     },
     "api_url": "https://lms.uantwerpen.be/"
   },


### PR DESCRIPTION
- Updated universities.json with the correct URLs for the University of Antwerp (since they changed in 2022-2023)
- Small fix for a UnicodeEncodeError (" 'charmap' codec can't encode character '\u200b' in position 392: character maps to <undefined>")