### PR TITLE
Add button to force login complete signal to login webview

### DIFF
--- a/blackboard_sync/qt/LoginWebView.ui
+++ b/blackboard_sync/qt/LoginWebView.ui
@@ -25,12 +25,28 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QWebEngineView" name="web_view">
+    <widget class="QWebEngineView" name="web_view" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
      <property name="toolTip">
       <string/>
      </property>
      <property name="statusTip">
       <string/>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="done_button">
+     <property name="toolTip">
+      <string>This window should close automatically, otherwise please click</string>
+     </property>
+     <property name="text">
+      <string>Click If Stuck After Logging In</string>
      </property>
     </widget>
    </item>

--- a/blackboard_sync/qt/qt_elements.py
+++ b/blackboard_sync/qt/qt_elements.py
@@ -479,6 +479,7 @@ class LoginWebView(QWidget):
         Assets.load_ui(self)
         self.web_view.load(QUrl.fromUserInput(self.start_url))
         self.web_view.loadFinished.connect(self._page_load_handler)
+        self.done_button.clicked.connect(self._login_complete_signal)
         self._cookie_store.cookieAdded.connect(self._cookie_added_handler)
 
     def _page_load_handler(self) -> None:


### PR DESCRIPTION
In some circumstances, it is good to have a way for users to manually mark their login process as complete, for instance if the university URLs are outdated or not correct. This change would enable such cases to still complete login, though there is still the need to communicate the fact that these URLs are not working to us. 