### PR TITLE
Allow BBResourceType to have arbitrary value (Closes #117)

### DIFF
--- a/blackboard_sync/blackboard/blackboard.py
+++ b/blackboard_sync/blackboard/blackboard.py
@@ -119,10 +119,15 @@ class BBResourceType(str, Enum):
     courselink = 'x-bb-courselink'
     blankpage = 'x-bb-blankpage'
     lesson = 'x-bb-lesson'
+    other = '__blackboardsync_other'
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.other
 
 
 class BBContentHandler(ImmutableModel):
-    id: Union[BBResourceType, str, None] = None
+    id: Optional[BBResourceType] = None
     url: Optional[str] = None
     file: Optional[BBFile] = None
     gradeColumnId: Optional[str] = None
@@ -133,10 +138,10 @@ class BBContentHandler(ImmutableModel):
     assessmentId: Optional[str] = None
     proctoring: Optional[BBProctoring] = None
 
-    @field_validator('id')
-    def resource_parser(cls, v: Union[BBResourceType, str]):
-        """Validate and parse an id resource type."""
-        return BBResourceType(v.replace('resource/', ''))
+    @field_validator('id', mode='before')
+    @classmethod
+    def trim_resource_type(cls, v: str) -> str:
+        return v.replace('resource/', '')
 
     @property
     def is_not_handled(self) -> bool:

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -10,11 +10,11 @@ from blackboard_sync.blackboard import (
     BBCourseContent, BBAvailability)
 
 
-resource_types = ('x-bb-folder', 'x-bb-file', 'x-bb-document', 'x-bb-blankpage',
-                  'x-bb-externallink', 'x-bb-courselink', 'x-bb-syllabus', 'x-bb-toollink',
-                  'x-bb-assignment', 'x-turnitin-assignment',
-                  'x-bb-asmt-test-link', 'x-bb-bltiplacement-Portal')
-
+handled_resource_types = ('x-bb-folder', 'x-bb-file', 'x-bb-document', 'x-bb-externallink')
+unhandled_resource_types = ('x-bb-blankpage', 'x-bb-courselink', 'x-bb-syllabus', 'x-bb-toollink',
+                            'x-bb-assignment', 'x-turnitin-assignment', 'x-bb-asmt-test-link',
+                            'x-bb-bltiplacement-Portal', 'x-bb-bltiplacement-mediasite.lesopnames')
+resource_types = handled_resource_types + unhandled_resource_types
 
 class BlackboardCourseName(BaseModel):
     code: str
@@ -24,6 +24,18 @@ class BlackboardCourseName(BaseModel):
     @property
     def name(self):
         return f"{self.code} : {self.title}, {self.details}"
+
+
+@composite
+def bb_unhandled_resource_type(draw: DrawFn) -> str:
+    res_type = draw(st.sampled_from(unhandled_resource_types))
+    return f"resource/{res_type}"
+
+
+@composite
+def bb_handled_resource_type(draw: DrawFn) -> str:
+    res_type = draw(st.sampled_from(handled_resource_types))
+    return f"resource/{res_type}"
 
 
 @composite

--- a/tests/test_blackboard.py
+++ b/tests/test_blackboard.py
@@ -23,10 +23,10 @@ from pathvalidate import sanitize_filename
 
 from blackboard_sync.blackboard import (BBFile, BBLink, BBCourse, BBLocale,
                                         BBDuration, BBAttachment, BBEnrollment,
-                                        BBMembership, BBProctoring,
-                                        BBContentChild, BBCourseContent)
+                                        BBMembership, BBProctoring, BBResourceType,
+                                        BBContentChild, BBCourseContent, BBContentHandler)
 
-from .strategies import bb_resource_type
+from .strategies import bb_unhandled_resource_type, bb_handled_resource_type, bb_resource_type
 
 
 class TestBBCourseContent:
@@ -56,3 +56,15 @@ class TestBBCourseContent:
         safe_path = sanitize_filename(filename or 'Title missing', replacement_text='_')
         obj = BBCourseContent(title=filename)
         assert safe_path or '' == obj.title_path_safe
+
+    @given(bb_resource_type())
+    def test_content_handler(self, res_type: str):
+        assert BBContentHandler(id=res_type).id in (res_type.split('/')[-1], BBResourceType.other)
+
+    @given(bb_handled_resource_type())
+    def test_content_handler_handled(self, res_type: str):
+        assert not (BBContentHandler(id=res_type).is_not_handled)
+
+    @given(bb_unhandled_resource_type())
+    def test_content_handler_unhandled(self, res_type: str):
+        assert BBContentHandler(id=res_type).is_not_handled


### PR DESCRIPTION
Since #117 showed that Blackboard may have arbitrary and unpredictable values for the Resource Type enum, this change will let any such values be grouped under a `BBResourceType.other` member.
The validator in `BBContentHandler` was also refactored to be executed before type coercion, so that the 'resource/' prefix can be removed while letting pydantic handle the conversion to the enum type.
Tests were added for `BBContentHandler` to confirm the aforementioned changes work as expected.